### PR TITLE
Removed tag from ImageStream

### DIFF
--- a/vertx-s2i-all.json
+++ b/vertx-s2i-all.json
@@ -62,7 +62,7 @@
             "name": "centos"
          },
          "spec": {
-            "dockerImageRepository": "centos:7"
+            "dockerImageRepository": "centos"
          }
       },
       {


### PR DESCRIPTION
OCP 3.4 was giving this error: The ImageStream "centos" is invalid: spec.dockerImageRepository: Invalid value: "centos:7": the repository name may not contain a tag

This PR fixes this Error